### PR TITLE
fix: use float16 in VLLMEngine when bfloat16 is unsupported

### DIFF
--- a/.github/workflows/run-tests-gpu.yaml
+++ b/.github/workflows/run-tests-gpu.yaml
@@ -21,7 +21,7 @@ jobs:
           - name: Setup | Install Git
             run: |
               apt-get update -qq
-              apt-get install -y --no-install-recommends git
+              apt-get install -y --no-install-recommends git build-essential
 
           - name: Setup | Checkout
             uses: actions/checkout@v4

--- a/mostlyai/engine/_language/engine/vllm_engine.py
+++ b/mostlyai/engine/_language/engine/vllm_engine.py
@@ -16,6 +16,8 @@ import contextlib
 from os import PathLike
 import time
 import typing
+
+from mostlyai.engine._language.common import is_bf16_supported
 from mostlyai.engine._language.engine.base import EngineMetrics, LanguageEngine
 import torch
 from formatron.config import EngineGenerationConfig
@@ -105,6 +107,7 @@ class VLLMEngine(LanguageEngine):
             device=device.type,
             max_model_len=min(config_max_model_len, self.tokenizer_max_length + max_new_tokens),
             enable_lora=True,
+            dtype=torch.bfloat16 if is_bf16_supported(device) else torch.float16,
             # enforce_eager=True,  # results in big slowdown, but is needed when running pytest locally
             swap_space=0,
             disable_log_stats=True,


### PR DESCRIPTION
Some older generations of GPU (e.g., T4 in Google Colab) does not support `bfloat16` dtype and resulted in errors during generation. This PR fixes the issue by using `float16` in this case.