### PR TITLE
fix: use default values for `max_training_time` / `max_epochs` if `None` passed

### DIFF
--- a/mostlyai/engine/training.py
+++ b/mostlyai/engine/training.py
@@ -49,7 +49,7 @@ def train(
     Args:
         model: The identifier of the model to train. If tabular, defaults to MOSTLY_AI/Medium. If language, defaults to MOSTLY_AI/LSTMFromScratch-3m.
         max_training_time: Maximum training time in minutes. If None, defaults to 10 days.
-        max_epochs: Maximum number of training epochs. If None, defaults to 100.
+        max_epochs: Maximum number of training epochs. If None, defaults to 100 epochs.
         batch_size: Per-device batch size for training and validation. If None, determined automatically.
         gradient_accumulation_steps: Number of steps to accumulate gradients. If None, determined automatically.
         enable_flexible_generation: Whether to enable flexible order generation. Defaults to True.

--- a/mostlyai/engine/training.py
+++ b/mostlyai/engine/training.py
@@ -26,8 +26,8 @@ from mostlyai.engine._workspace import resolve_model_type
 def train(
     *,
     model: str | None = None,
-    max_training_time: float = 14400.0,  # 10 days
-    max_epochs: float = 100.0,  # 100 epochs
+    max_training_time: float | None = 14400.0,  # 10 days
+    max_epochs: float | None = 100.0,  # 100 epochs
     batch_size: int | None = None,
     gradient_accumulation_steps: int | None = None,
     enable_flexible_generation: bool = True,
@@ -48,8 +48,8 @@ def train(
 
     Args:
         model: The identifier of the model to train. If tabular, defaults to MOSTLY_AI/Medium. If language, defaults to MOSTLY_AI/LSTMFromScratch-3m.
-        max_training_time: Maximum training time in minutes.
-        max_epochs: Maximum number of training epochs.
+        max_training_time: Maximum training time in minutes. If None, defaults to 10 days.
+        max_epochs: Maximum number of training epochs. If None, defaults to 100.
         batch_size: Per-device batch size for training and validation. If None, determined automatically.
         gradient_accumulation_steps: Number of steps to accumulate gradients. If None, determined automatically.
         enable_flexible_generation: Whether to enable flexible order generation. Defaults to True.
@@ -65,11 +65,12 @@ def train(
     if model_type == ModelType.tabular:
         from mostlyai.engine._tabular.training import train as train_tabular
 
+        args = inspect.signature(train_tabular).parameters
         train_tabular(
-            model=model if model else inspect.signature(train_tabular).parameters["model"].default,
+            model=model if model else args["model"].default,
             workspace_dir=workspace_dir,
-            max_training_time=max_training_time,
-            max_epochs=max_epochs,
+            max_training_time=max_training_time if max_training_time else args["max_training_time"].default,
+            max_epochs=max_epochs if max_epochs else args["max_epochs"].default,
             batch_size=batch_size,
             gradient_accumulation_steps=gradient_accumulation_steps,
             enable_flexible_generation=enable_flexible_generation,
@@ -78,9 +79,7 @@ def train(
             upload_model_data_callback=upload_model_data_callback,
             model_state_strategy=model_state_strategy,
             device=device,
-            max_sequence_window=max_sequence_window
-            if max_sequence_window
-            else inspect.signature(train_tabular).parameters["max_sequence_window"].default,
+            max_sequence_window=max_sequence_window if max_sequence_window else args["max_sequence_window"].default,
         )
     else:
         from mostlyai.engine._language.training import train as train_language
@@ -88,11 +87,12 @@ def train(
         if max_sequence_window is not None:
             raise ValueError("max_sequence_window is not supported for language models")
 
+        args = inspect.signature(train_language).parameters
         train_language(
-            model=model if model else inspect.signature(train_language).parameters["model"].default,
+            model=model if model else args["model"].default,
             workspace_dir=workspace_dir,
-            max_training_time=max_training_time,
-            max_epochs=max_epochs,
+            max_training_time=max_training_time if max_training_time else args["max_training_time"].default,
+            max_epochs=max_epochs if max_epochs else args["max_epochs"].default,
             batch_size=batch_size,
             gradient_accumulation_steps=gradient_accumulation_steps,
             enable_flexible_generation=enable_flexible_generation,


### PR DESCRIPTION
Tested with: 

```python
from pathlib import Path
import pandas as pd
from mostlyai import engine
ws = Path("ws-tabular-flat")
engine.init_logging()
url = "https://github.com/mostly-ai/public-demo-data/raw/refs/heads/dev/census"
trn_df = pd.read_csv(f"{url}/census.csv.gz")
engine.split(
  workspace_dir=ws,
  tgt_data=trn_df,
  model_type="TABULAR",
)
engine.analyze(workspace_dir=ws)
engine.encode(workspace_dir=ws)
engine.train(workspace_dir=ws, max_training_time=None, max_epochs=None)
```