### PR TITLE
fix: decode_character to gracefully handle null column with unique index

### DIFF
--- a/mostlyai/engine/_encoding_types/tabular/character.py
+++ b/mostlyai/engine/_encoding_types/tabular/character.py
@@ -155,7 +155,7 @@ def decode_character(df_encoded: pd.DataFrame, stats: dict) -> pd.Series:
         values = values.apply(lambda item: item.replace(UNKNOWN_TOKEN, "")).str.rstrip()
     else:
         # handle de-generate case, where no tokens were stored
-        values = pd.Series(pd.NA).repeat(df_encoded.shape[0])
+        values = pd.Series(pd.NA, index=range(df_encoded.shape[0]))
     if stats["has_nan"]:
         values[df_encoded["nan"] == 1] = pd.NA
     return values

--- a/tests/unit/encoding_types/tabular/test_character.py
+++ b/tests/unit/encoding_types/tabular/test_character.py
@@ -75,6 +75,7 @@ def test_character_empty():
     df_encoded = encode_character(values, stats)
     df_decoded = decode_character(df_encoded, stats)
     assert all(df_decoded.isna())
+    assert df_decoded.index.is_unique
 
     values = pd.Series(["hello", None, None], name="value")
     df_encoded = encode_character(values, stats)


### PR DESCRIPTION
The bug was due to a non-unique index column, and therefore it was failing in the end of `_decode_df` run.
![Screenshot 2025-07-08 at 14 59 33](https://github.com/user-attachments/assets/23b43d96-4453-4363-a5af-5ef7983efb23)

This fix assigns unique indices for the "only nulls" case:
![Screenshot 2025-07-08 at 15 00 02](https://github.com/user-attachments/assets/4d428584-74bc-4db1-8273-7e5691774c31)