### PR TITLE
fix: SCP issue caused by inconsistent context sequence length stats

### DIFF
--- a/mostlyai/engine/_common.py
+++ b/mostlyai/engine/_common.py
@@ -401,12 +401,11 @@ def get_sub_columns_lookup(
     return sub_cols_lookup
 
 
-class CtxSequenceLengthError(Exception):
-    """Error raised when the cols of the same table do not have the same stats value"""
-
-
 def get_ctx_sequence_length(ctx_stats: dict, key: str) -> dict[str, int]:
-    seq_stats: dict[str, int] = {}
+    """
+    Get the stats of sequence lengths from the first column_stats of each context table
+    """
+    ctxseq_stats: dict[str, int] = {}
 
     for column_stats in ctx_stats.get("columns", {}).values():
         if "seq_len" in column_stats:
@@ -414,12 +413,10 @@ def get_ctx_sequence_length(ctx_stats: dict, key: str) -> dict[str, int]:
                 argn_processor=column_stats[ARGN_PROCESSOR],
                 argn_table=column_stats[ARGN_TABLE],
             )
-            cur_value = seq_stats.get(table)
-            if cur_value and cur_value != column_stats["seq_len"][key]:
-                raise CtxSequenceLengthError()
-            seq_stats[table] = column_stats["seq_len"][key]
+            if table not in ctxseq_stats:
+                ctxseq_stats[table] = column_stats["seq_len"][key]
 
-    return seq_stats
+    return ctxseq_stats
 
 
 def get_max_data_points_per_sample(stats: dict) -> int:

--- a/tests/unit/test_common.py
+++ b/tests/unit/test_common.py
@@ -24,7 +24,6 @@ from mostlyai.engine._common import (
     ARGN_COLUMN,
     ARGN_PROCESSOR,
     ARGN_TABLE,
-    CtxSequenceLengthError,
     apply_encoding_type_dtypes,
     dp_non_rare,
     dp_quantiles,
@@ -505,36 +504,6 @@ class TestGetCtxSequenceLength:
         assert get_ctx_sequence_length(stats, key="min") == {"ctxseq:t1": 1}
         assert get_ctx_sequence_length(stats, key="max") == {"ctxseq:t1": 3}
         assert get_ctx_sequence_length(stats, key="median") == {"ctxseq:t1": 2}
-
-    def test_raise_exception_when_cols_not_converge(self):
-        stats = {
-            "columns": {
-                "table0.col0": {
-                    ARGN_PROCESSOR: "ctxflt",
-                    ARGN_TABLE: "t0",
-                    ARGN_COLUMN: "c0",
-                },
-                "table1.col0": {
-                    ARGN_PROCESSOR: "ctxseq",
-                    "seq_len": {
-                        "any-key": 2,
-                    },
-                    ARGN_TABLE: "t1",
-                    ARGN_COLUMN: "c1",
-                },
-                "table1.col1": {
-                    ARGN_PROCESSOR: "ctxseq",
-                    "seq_len": {
-                        "any-key": 9,
-                    },
-                    ARGN_TABLE: "t1",
-                    ARGN_COLUMN: "c2",
-                },
-            }
-        }
-
-        with pytest.raises(CtxSequenceLengthError):
-            assert get_ctx_sequence_length(stats, key="any-key")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
There were two issues:
- `value_protection` flag was not propagated correctly when we were analyzing the context sequence length => it's always `True` by default
-  We re-analyzed the length of each context sequence, which was redundant. This also resulted in each context sequence column having different stats (min/median/max) of lengths. The columns of the same subject thus got capped into inconsistent lengths.

These caused the two errors reported by the customer:
- `mostlyai.engine._common.CtxSequenceLengthError` from `get_ctx_sequence_length()`
- RuntimeError during forward step of SequentialContextProcessor during training: `RuntimeError: Sizes of tensors must match except in dimension 2. Expected size X but got size Y for tensor number Z in the list`.

This PR fixes the issue by
- Only analyze sequence length of a context table once to avoid inconsistent stats
- fix the propagation of `value_protection` flag (+ correct the different privacy budget)
