### PR TITLE
fix: edge case of DP value protection caused by all-null column

### DIFF
--- a/mostlyai/engine/_common.py
+++ b/mostlyai/engine/_common.py
@@ -864,6 +864,7 @@ def dp_non_rare(value_counts: dict[str, int], epsilon: float, threshold: int = 5
     noisy_counts = np.clip(np.array(list(value_counts.values())) + noise, 0, None).astype(int)
     for i, cat in enumerate(value_counts):
         value_counts[cat] = noisy_counts[i]
+    # NOTE: total_counts can be 0 in the edge case when the column only has null values
     total_counts = sum(value_counts.values())
 
     # 2. Collect all categories whose noisy count >= threshold
@@ -871,7 +872,7 @@ def dp_non_rare(value_counts: dict[str, int], epsilon: float, threshold: int = 5
 
     # 3. Compute the non-rare ratio
     noisy_total_counts = sum(selected.values())
-    non_rare_ratio = noisy_total_counts / total_counts
+    non_rare_ratio = noisy_total_counts / total_counts if total_counts > 0 else 0
 
     return list(selected.keys()), non_rare_ratio
 

--- a/tests/unit/test_common.py
+++ b/tests/unit/test_common.py
@@ -625,11 +625,18 @@ def test_dp_quantiles():
     assert q5_dp is None and q95_dp is None
 
 
-def test_dp_non_rare():
-    value_counts = {i: i for i in range(1, 101)}
+@pytest.mark.parametrize(
+    "value_counts, expected_selected_range, expected_non_rare_ratio_range",
+    [
+        # given epsilon=1.0, the noise added to the count should be within the range [-5, 5]
+        # so in the worst case, we will have at least 4 and at most at most 14 rare categories
+        ({i: i for i in range(1, 101)}, [86, 96], [0.98, 1.0]),
+        # all the categories are rare
+        ({}, [0, 0], [0, 0]),
+    ],
+)
+def test_dp_non_rare(value_counts, expected_selected_range, expected_non_rare_ratio_range):
     epsilon = 1.0
     selected, non_rare_ratio = dp_non_rare(value_counts, epsilon, threshold=10)
-    # given epsilon=1.0, the noise added to the count should be within the range [-5, 5]
-    # so in the worst case, we will have at least 4 and at most at most 14 rare categories
-    assert len(selected) >= 86 and len(selected) <= 96
-    assert non_rare_ratio >= 0.98 and non_rare_ratio <= 1.0
+    assert len(selected) >= expected_selected_range[0] and len(selected) <= expected_selected_range[1]
+    assert non_rare_ratio >= expected_non_rare_ratio_range[0] and non_rare_ratio <= expected_non_rare_ratio_range[1]

--- a/tests/unit/test_common.py
+++ b/tests/unit/test_common.py
@@ -638,5 +638,5 @@ def test_dp_quantiles():
 def test_dp_non_rare(value_counts, expected_selected_range, expected_non_rare_ratio_range):
     epsilon = 1.0
     selected, non_rare_ratio = dp_non_rare(value_counts, epsilon, threshold=10)
-    assert len(selected) >= expected_selected_range[0] and len(selected) <= expected_selected_range[1]
-    assert non_rare_ratio >= expected_non_rare_ratio_range[0] and non_rare_ratio <= expected_non_rare_ratio_range[1]
+    assert expected_selected_range[0] <= len(selected) <= expected_selected_range[1]
+    assert expected_non_rare_ratio_range[0] <= non_rare_ratio <= expected_non_rare_ratio_range[1]

--- a/tests/unit/test_common.py
+++ b/tests/unit/test_common.py
@@ -631,7 +631,7 @@ def test_dp_quantiles():
         # given epsilon=1.0, the noise added to the count should be within the range [-5, 5]
         # so in the worst case, we will have at least 4 and at most at most 14 rare categories
         ({i: i for i in range(1, 101)}, [86, 96], [0.98, 1.0]),
-        # all the categories are rare
+        # all the values of the column are null, hence empty value_counts
         ({}, [0, 0], [0, 0]),
     ],
 )


### PR DESCRIPTION
In an edge case where DP value protection is on and a `TABULAR_CATEGORICAL/TABULAR_LAT_LONG/TABULAR_CHARACTER` column has all-null values, there're no counts for the categories. `total_counts` therefore becomes 0 and triggers the zero division error.