### PR TITLE
fix: non-rare ratio of all-null column

### DIFF
--- a/mostlyai/engine/_common.py
+++ b/mostlyai/engine/_common.py
@@ -872,7 +872,7 @@ def dp_non_rare(value_counts: dict[str, int], epsilon: float, threshold: int = 5
 
     # 3. Compute the non-rare ratio
     noisy_total_counts = sum(selected.values())
-    non_rare_ratio = noisy_total_counts / total_counts if total_counts > 0 else 0
+    non_rare_ratio = noisy_total_counts / total_counts if total_counts > 0 else 1.0
 
     return list(selected.keys()), non_rare_ratio
 

--- a/mostlyai/engine/_encoding_types/tabular/numeric.py
+++ b/mostlyai/engine/_encoding_types/tabular/numeric.py
@@ -282,7 +282,7 @@ def analyze_reduce_numeric(
             non_rare_ratio = 1.0
     else:
         categories = []
-        non_rare_ratio = 0.0
+        non_rare_ratio = 1.0
 
     # auto heuristic
     if encoding_type == ModelEncodingType.tabular_numeric_auto:

--- a/tests/unit/encoding_types/tabular/test_numeric.py
+++ b/tests/unit/encoding_types/tabular/test_numeric.py
@@ -327,6 +327,13 @@ class TestDigitAnalyzeReduce:
         assert result["min"] == 0.0
         assert result["max"] == 30.0
 
+    def test_all_nulls(self):
+        stats = self.stats_template(has_nan=True, cnt_values={})
+        result = analyze_reduce_numeric([stats], encoding_type=ModelEncodingType.tabular_numeric_auto)
+        assert result["encoding_type"] == ModelEncodingType.tabular_numeric_discrete
+        assert result["cardinalities"] == {"cat": 2}  # only rare and null
+        assert result["min_decimal"] == 0
+
 
 class TestDigitEncode:
     @pytest.fixture

--- a/tests/unit/test_common.py
+++ b/tests/unit/test_common.py
@@ -632,7 +632,7 @@ def test_dp_quantiles():
         # so in the worst case, we will have at least 4 and at most at most 14 rare categories
         ({i: i for i in range(1, 101)}, [86, 96], [0.98, 1.0]),
         # all the values of the column are null, hence empty value_counts
-        ({}, [0, 0], [0, 0]),
+        ({}, [0, 0], [1.0, 1.0]),
     ],
 )
 def test_dp_non_rare(value_counts, expected_selected_range, expected_non_rare_ratio_range):


### PR DESCRIPTION
When a `TABULAR_NUMERIC_AUTO` column only has null values, non_rare_ratio should be set to 1.0, so that it will be resolved as `TABULAR_NUMERIC_DISCRETE` (which is slightly more suitable than `TABULAR_NUMERIC_DIGIT`)