### PR TITLE
perf: simplify embedding heuristics

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
         # - --remove-header
         - --license-filepath
         - LICENSE_HEADER
-        - --use-current-year
+        # - --use-current-year
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v5.0.0
   hooks:

--- a/mostlyai/engine/_tabular/argn.py
+++ b/mostlyai/engine/_tabular/argn.py
@@ -1,4 +1,4 @@
-# Copyright 2025-2026 MOSTLY AI
+# Copyright 2025 MOSTLY AI
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/mostlyai/engine/_tabular/argn.py
+++ b/mostlyai/engine/_tabular/argn.py
@@ -1,4 +1,4 @@
-# Copyright 2025 MOSTLY AI
+# Copyright 2025-2026 MOSTLY AI
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -117,9 +117,9 @@ def _embedding_heuristic(id: str, model_size: ModelSizeOrUnits, dim_input: int) 
     if isinstance(model_size, dict):
         return model_size[id]
     model_size_output_dim = dict(
-        S=max(10, int(2 * np.ceil(dim_input**0.15))),
-        M=max(10, int(3 * np.ceil(dim_input**0.25))),
-        L=max(10, int(4 * np.ceil(dim_input**0.33))),
+        S=int(2 * np.ceil(dim_input**0.15)),
+        M=int(3 * np.ceil(dim_input**0.25)),
+        L=int(4 * np.ceil(dim_input**0.33)),
     )
     return min(dim_input, model_size_output_dim[model_size])
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Streamlines embedding size computation in `TabularARGN`.
> 
> - Updates `_embedding_heuristic` to drop the `max(10, ...)` floor; sizes are now `S=2*ceil(dim^0.15)`, `M=3*ceil(dim^0.25)`, `L=4*ceil(dim^0.33)`, still capped by `dim_input`
> - Pre-commit: comment out `--use-current-year` for `insert-license`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 216a3fa4220908ec5b4fc06e2e5e21bba9d1250c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->