### PR TITLE
ci: run GPU tests only for gpu commits

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -21,8 +21,7 @@ jobs:
     secrets: inherit
   run-tests-gpu:
     if: |
-      github.ref == 'refs/heads/main' ||
-      startsWith(github.ref, 'refs/tags/') ||
+      github.event_name == 'push' &&
       contains(github.event.head_commit.message, '[gpu]')
     uses: ./.github/workflows/run-tests-gpu.yaml
     secrets: inherit


### PR DESCRIPTION
## Summary
- run GPU tests only on push events where the commit message contains [gpu]
- stop auto-running GPU tests on main branch pushes and tag pushes

## Testing
- not run (CI workflow condition change)