### PR TITLE
chore: drop Python 3.10 tooling references

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,7 +47,7 @@ repos:
     rev: v3.19.1
     hooks:
     -   id: pyupgrade
-        args: [--py310-plus]
+        args: [--py311-plus]
 - repo: https://github.com/astral-sh/ruff-pre-commit
   rev: v0.11.6
   hooks:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,12 +23,12 @@ Thanks for your interest in contributing to Synthetic Data Engine! Follow these 
 
 3. **Create a virtual environment and install dependencies**:
    ```bash
-   uv sync --frozen --extra cpu --python=3.10  # For CPU-only
+   uv sync --frozen --extra cpu --python=3.11  # For CPU-only
    source .venv/bin/activate
    ```
    If using GPU, run:
    ```bash
-   uv sync --frozen --extra gpu --python=3.10  # For GPU support
+   uv sync --frozen --extra gpu --python=3.11  # For GPU support
    source .venv/bin/activate
    ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,7 @@ requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [tool.ruff]
-target-version = "py310"
+target-version = "py311"
 line-length = 120
 extend-exclude = ["*.ipynb"]
 [tool.ruff.format]


### PR DESCRIPTION
## Summary
- update Ruff target version from `py310` to `py311` in `pyproject.toml`
- update `pyupgrade` pre-commit hook from `--py310-plus` to `--py311-plus`
- update contributor setup commands to use Python 3.11 in `CONTRIBUTING.md`

## Test plan
- [x] verify no remaining 3.10 support references in project config/docs
- [x] run pre-commit hooks triggered by commit

Made with [Cursor](https://cursor.com)