### PR TITLE
Add GitHub issues URL to pyproject metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ docs = [
 [project.urls]
 homepage = "https://github.com/mostly-ai/mostlyai-engine"
 repository = "https://github.com/mostly-ai/mostlyai-engine"
+issues = "https://github.com/mostly-ai/mostlyai-engine/issues"
 documentation = "https://mostly-ai.github.io/mostlyai-engine/"
 
 [tool.uv]


### PR DESCRIPTION
Adds the standard PEP 621 `issues` entry under `[project.urls]` pointing at the GitHub issue tracker (`https://github.com/mostly-ai/mostlyai-engine/issues`). This improves discoverability from PyPI and other tools that read project URLs.

Made with [Cursor](https://cursor.com)